### PR TITLE
Remove stale chart sources

### DIFF
--- a/chartsources.txt
+++ b/chartsources.txt
@@ -1,5 +1,2 @@
 https://github.com/jonfairbanks/docker-node-app;chart;docker-node-app
-https://github.com/jonfairbanks/jonfairbanks.github.io;chart;jonfairbanks-homepage
 https://github.com/jonfairbanks/helm-charts;rick;rick
-https://github.com/jonfairbanks/yo;/client/chart;yo-client
-https://github.com/jonfairbanks/yo;/server/chart;yo-api


### PR DESCRIPTION
## Summary

Remove three chart source entries whose chart paths no longer exist.

These stale sources caused every Helm repository index rebuild to stop before updating `index.yaml`, including the docker-node-app 3.0.0 publication.

Valid `docker-node-app` and `rick` sources remain.