### PR TITLE
Use canonical HTTPS landing page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Helm charts published as public OCI artifacts in GitHub Container Registry.
 
-Browse the chart catalog at [jonfairbanks.github.io/helm-charts](https://jonfairbanks.github.io/helm-charts/).
+Browse the chart catalog at [fairbanks.io/helm-charts](https://fairbanks.io/helm-charts/).
 
 ## Rick
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Public OCI Helm charts by Jon Fairbanks.">
   <meta name="theme-color" content="#08110f">
+  <link rel="canonical" href="https://fairbanks.io/helm-charts/">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='16' fill='%2308110f'/%3E%3Ccircle cx='16' cy='16' r='9' fill='none' stroke='%23b7f34a' stroke-width='3'/%3E%3C/svg%3E">
   <title>Fairbanks Helm Charts</title>
   <script>document.documentElement.classList.add('js');</script>


### PR DESCRIPTION
Links directly to the verified HTTPS custom-domain landing page and adds the canonical URL to the page metadata.