### PR TITLE
Fix docker-node-app install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm upgrade rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.0
 ## docker-node-app
 
 ```sh
-helm install my-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1
+helm install docker-node-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1
 ```
 
 The docker-node-app chart is maintained and published from

--- a/index.html
+++ b/index.html
@@ -369,8 +369,8 @@
             </div>
           </div>
           <div class="install">
-            <code>helm install my-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1</code>
-            <button class="copy" type="button" data-copy="helm install my-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1" aria-label="Copy docker-node-app install command">Copy</button>
+            <code>helm install docker-node-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1</code>
+            <button class="copy" type="button" data-copy="helm install docker-node-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1" aria-label="Copy docker-node-app install command">Copy</button>
           </div>
         </article>
       </div>


### PR DESCRIPTION
Correct the docker-node-app install examples to use `docker-node-app` as the Helm release name.

This updates the README and the published catalog copy command, so both user-facing entry points agree.

Validated with an exact-command search and `git diff --check`.