### PR TITLE
Create namespaces in chart install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Browse the chart catalog at [fairbanks.io/helm-charts](https://fairbanks.io/helm
 ## Rick
 
 ```sh
-helm install rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.0
+helm install rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.0 --namespace rick --create-namespace
 ```
 
 Upgrade an existing release after reviewing the [Rick 2.0.0 breaking changes](#rick-200-breaking-changes):
@@ -19,7 +19,7 @@ helm upgrade rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.0
 ## docker-node-app
 
 ```sh
-helm install docker-node-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1
+helm install docker-node-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1 --namespace docker-node-app --create-namespace
 ```
 
 The docker-node-app chart is maintained and published from

--- a/index.html
+++ b/index.html
@@ -349,8 +349,8 @@
             </div>
           </div>
           <div class="install">
-            <code>helm install rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.0</code>
-            <button class="copy" type="button" data-copy="helm install rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.0" aria-label="Copy Rick install command">Copy</button>
+            <code>helm install rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.0 --namespace rick --create-namespace</code>
+            <button class="copy" type="button" data-copy="helm install rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.0 --namespace rick --create-namespace" aria-label="Copy Rick install command">Copy</button>
           </div>
         </article>
 
@@ -369,8 +369,8 @@
             </div>
           </div>
           <div class="install">
-            <code>helm install docker-node-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1</code>
-            <button class="copy" type="button" data-copy="helm install docker-node-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1" aria-label="Copy docker-node-app install command">Copy</button>
+            <code>helm install docker-node-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1 --namespace docker-node-app --create-namespace</code>
+            <button class="copy" type="button" data-copy="helm install docker-node-app oci://ghcr.io/jonfairbanks/charts/docker-node-app --version 3.0.1 --namespace docker-node-app --create-namespace" aria-label="Copy docker-node-app install command">Copy</button>
           </div>
         </article>
       </div>


### PR DESCRIPTION
Add chart-specific namespaces to the install examples and create them when absent.

The site catalog, its copy buttons, and the README now use `--namespace` with `--create-namespace` for both published charts.

Validated with an exact-command search and `git diff --check`.