### PR TITLE
Add default resource limits to Rick chart

### DIFF
--- a/.github/workflows/rick.yml
+++ b/.github/workflows/rick.yml
@@ -114,6 +114,10 @@ jobs:
           grep --quiet 'port: health' "$manifest"
           grep --quiet 'targetPort: http' "$manifest"
           grep --quiet 'automountServiceAccountToken: false' "$manifest"
+          grep --quiet --fixed-strings 'cpu: 10m' "$manifest"
+          grep --quiet --fixed-strings 'memory: 50Mi' "$manifest"
+          grep --quiet --fixed-strings 'cpu: 25m' "$manifest"
+          grep --quiet --fixed-strings 'memory: 64Mi' "$manifest"
           ! grep --quiet --extended-regexp 'v1beta1|v2beta1|v2beta2' /tmp/rendered/*.yaml
 
   publish:

--- a/.github/workflows/rick.yml
+++ b/.github/workflows/rick.yml
@@ -116,8 +116,8 @@ jobs:
           grep --quiet 'automountServiceAccountToken: false' "$manifest"
           grep --quiet --fixed-strings 'cpu: 10m' "$manifest"
           grep --quiet --fixed-strings 'memory: 50Mi' "$manifest"
-          grep --quiet --fixed-strings 'cpu: 25m' "$manifest"
           grep --quiet --fixed-strings 'memory: 64Mi' "$manifest"
+          ! grep --quiet --fixed-strings 'cpu: 25m' "$manifest"
           ! grep --quiet --extended-regexp 'v1beta1|v2beta1|v2beta2' /tmp/rendered/*.yaml
 
   publish:

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Browse the chart catalog at [fairbanks.io/helm-charts](https://fairbanks.io/helm
 ## Rick
 
 ```sh
-helm install rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.0 --namespace rick --create-namespace
+helm install rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.1 --namespace rick --create-namespace
 ```
 
 Upgrade an existing release after reviewing the [Rick 2.0.0 breaking changes](#rick-200-breaking-changes):
 
 ```sh
-helm upgrade rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.0
+helm upgrade rick oci://ghcr.io/jonfairbanks/charts/rick --version 2.0.1
 ```
 
 ## docker-node-app

--- a/rick/Chart.yaml
+++ b/rick/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rick
 description: A self-hosted, self-contained Rickroll
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: "1080p"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/jonfairbanks/helm-charts

--- a/rick/values.yaml
+++ b/rick/values.yaml
@@ -52,6 +52,9 @@ resources:
   requests:
     cpu: 10m
     memory: 50Mi
+  limits:
+    cpu: 25m
+    memory: 64Mi
 
 autoscaling:
   enabled: false

--- a/rick/values.yaml
+++ b/rick/values.yaml
@@ -53,7 +53,6 @@ resources:
     cpu: 10m
     memory: 50Mi
   limits:
-    cpu: 25m
     memory: 64Mi
 
 autoscaling:


### PR DESCRIPTION
## Summary

- Add default CPU and memory limits for the Rick application container.
- Assert the rendered default Deployment includes the configured requests and limits.
- Bump the Rick chart to 2.0.1 and update its installation examples.