### PR TITLE
Add private cluster docs chart

### DIFF
--- a/.github/workflows/k3s-cluster-docs.yml
+++ b/.github/workflows/k3s-cluster-docs.yml
@@ -1,0 +1,105 @@
+name: K3s cluster docs chart
+
+on:
+  pull_request:
+    paths:
+      - "k3s-cluster-docs/**"
+      - ".github/workflows/k3s-cluster-docs.yml"
+  push:
+    branches: [master]
+    paths:
+      - "k3s-cluster-docs/**"
+      - ".github/workflows/k3s-cluster-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  HELM_VERSION: v4.2.3
+  KUBECONFORM_VERSION: v0.8.0
+
+jobs:
+  validate:
+    name: Validate K3s cluster docs chart
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: ${{ env.HELM_VERSION }}
+      - name: Install kubeconform
+        run: |
+          archive="kubeconform-linux-amd64.tar.gz"
+          curl --fail --silent --show-error --location \
+            "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/${archive}" \
+            --output "/tmp/${archive}"
+          echo "9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883  /tmp/${archive}" | sha256sum --check
+          tar --extract --gzip --file "/tmp/${archive}" --directory /usr/local/bin kubeconform
+      - name: Require a chart version increment
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if git diff --quiet "origin/${BASE_REF}...HEAD" -- k3s-cluster-docs; then exit 0; fi
+          if ! git cat-file -e "origin/${BASE_REF}:k3s-cluster-docs/Chart.yaml" 2>/dev/null; then
+            exit 0
+          fi
+          base_version=$(git show "origin/${BASE_REF}:k3s-cluster-docs/Chart.yaml" | awk '/^version:/ { print $2; exit }')
+          current_version=$(awk '/^version:/ { print $2; exit }' k3s-cluster-docs/Chart.yaml)
+          if ! dpkg --compare-versions "$current_version" gt "$base_version"; then
+            echo "Chart version must increase beyond ${base_version}; found ${current_version}." >&2
+            exit 1
+          fi
+      - name: Lint, package, and render
+        run: |
+          helm lint --strict ./k3s-cluster-docs
+          helm package ./k3s-cluster-docs --destination /tmp/charts
+          helm template default ./k3s-cluster-docs --kube-version 1.36.2 > /tmp/default.yaml
+          helm template ingress ./k3s-cluster-docs --kube-version 1.36.2 \
+            --set ingress.enabled=true \
+            --set ingress.className=traefik \
+            --set ingress.hosts[0].host=cluster-docs.example.internal \
+            --set ingress.hosts[0].paths[0].path=/ \
+            --set ingress.hosts[0].paths[0].pathType=Prefix \
+            --set imagePullSecrets[0].name=ghcr-pull \
+            > /tmp/ingress.yaml
+          kubeconform -strict -summary -kubernetes-version 1.36.2 /tmp/default.yaml /tmp/ingress.yaml
+      - name: Assert runtime contract
+        run: |
+          grep --quiet 'automountServiceAccountToken: false' /tmp/default.yaml
+          grep --quiet 'readOnlyRootFilesystem: true' /tmp/default.yaml
+          grep --quiet 'containerPort: 8080' /tmp/default.yaml
+          grep --quiet 'path: /healthz' /tmp/default.yaml
+          grep --quiet 'name: ghcr-pull' /tmp/ingress.yaml
+
+  publish:
+    name: Publish private K3s cluster docs chart
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: ${{ env.HELM_VERSION }}
+      - name: Publish immutable chart version
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(awk '/^version:/ { print $2; exit }' k3s-cluster-docs/Chart.yaml)
+          chart=oci://ghcr.io/jonfairbanks/charts/k3s-cluster-docs
+          echo "$GHCR_TOKEN" | helm registry login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          if helm show chart "$chart" --version "$version" >/dev/null 2>&1; then
+            echo "${chart}:${version} already exists; increment k3s-cluster-docs/Chart.yaml." >&2
+            exit 1
+          fi
+          helm package ./k3s-cluster-docs --destination /tmp/charts
+          helm push "/tmp/charts/k3s-cluster-docs-${version}.tgz" oci://ghcr.io/jonfairbanks/charts

--- a/k3s-cluster-docs/.helmignore
+++ b/k3s-cluster-docs/.helmignore
@@ -1,0 +1,10 @@
+.DS_Store
+.git/
+.gitignore
+.github/
+.idea/
+.vscode/
+*.bak
+*.orig
+*.swp
+*~

--- a/k3s-cluster-docs/Chart.yaml
+++ b/k3s-cluster-docs/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: k3s-cluster-docs
+description: Private internal handbook for a K3s cluster
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+kubeVersion: ">=1.25.0-0"
+home: https://github.com/jonfairbanks/k3s-cluster-docs
+sources:
+  - https://github.com/jonfairbanks/k3s-cluster-docs
+maintainers:
+  - name: Jon Fairbanks
+    url: https://github.com/jonfairbanks

--- a/k3s-cluster-docs/Chart.yaml
+++ b/k3s-cluster-docs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k3s-cluster-docs
 description: Private internal handbook for a K3s cluster
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.0.1
+appVersion: "1.0.1"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/jonfairbanks/k3s-cluster-docs
 sources:

--- a/k3s-cluster-docs/templates/_helpers.tpl
+++ b/k3s-cluster-docs/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{- define "k3s-cluster-docs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "k3s-cluster-docs.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "k3s-cluster-docs.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ include "k3s-cluster-docs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "k3s-cluster-docs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "k3s-cluster-docs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "k3s-cluster-docs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "k3s-cluster-docs.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "k3s-cluster-docs.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end }}

--- a/k3s-cluster-docs/templates/deployment.yaml
+++ b/k3s-cluster-docs/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "k3s-cluster-docs.fullname" . }}
+  labels:
+    {{- include "k3s-cluster-docs.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "k3s-cluster-docs.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "k3s-cluster-docs.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "k3s-cluster-docs.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "k3s-cluster-docs.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: cache
+              mountPath: /var/cache/nginx
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: cache
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k3s-cluster-docs/templates/ingress.yaml
+++ b/k3s-cluster-docs/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "k3s-cluster-docs.fullname" . }}
+  labels:
+    {{- include "k3s-cluster-docs.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "k3s-cluster-docs.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/k3s-cluster-docs/templates/service.yaml
+++ b/k3s-cluster-docs/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "k3s-cluster-docs.fullname" . }}
+  labels:
+    {{- include "k3s-cluster-docs.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "k3s-cluster-docs.selectorLabels" . | nindent 4 }}

--- a/k3s-cluster-docs/templates/serviceaccount.yaml
+++ b/k3s-cluster-docs/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "k3s-cluster-docs.serviceAccountName" . }}
+  labels:
+    {{- include "k3s-cluster-docs.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/k3s-cluster-docs/templates/tests/test-connection.yaml
+++ b/k3s-cluster-docs/templates/tests/test-connection.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "k3s-cluster-docs.fullname" . }}-test-connection"
+  labels:
+    {{- include "k3s-cluster-docs.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  automountServiceAccountToken: false
+  containers:
+    - name: wget
+      image: busybox:1.37.0
+      command: ["wget"]
+      args: ["--spider", "{{ include "k3s-cluster-docs.fullname" . }}:{{ .Values.service.port }}/healthz"]
+  restartPolicy: Never

--- a/k3s-cluster-docs/values.schema.json
+++ b/k3s-cluster-docs/values.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["replicaCount", "image", "imagePullSecrets", "serviceAccount", "podAnnotations", "podSecurityContext", "securityContext", "containerPort", "service", "ingress", "resources", "nodeSelector", "tolerations", "affinity"],
+  "properties": {
+    "replicaCount": {"type": "integer", "minimum": 1},
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "tag", "digest", "pullPolicy"],
+      "properties": {
+        "repository": {"type": "string", "minLength": 1},
+        "tag": {"type": "string", "minLength": 1},
+        "digest": {"type": "string", "pattern": "^(|sha256:[a-f0-9]{64})$"},
+        "pullPolicy": {"enum": ["Always", "IfNotPresent", "Never"]}
+      }
+    },
+    "imagePullSecrets": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["name"], "properties": {"name": {"type": "string", "minLength": 1}}}},
+    "nameOverride": {"type": "string"},
+    "fullnameOverride": {"type": "string"},
+    "serviceAccount": {"type": "object", "additionalProperties": false, "required": ["create", "annotations", "name"], "properties": {"create": {"type": "boolean"}, "annotations": {"type": "object"}, "name": {"type": "string"}}},
+    "podAnnotations": {"type": "object"},
+    "podSecurityContext": {"type": "object"},
+    "securityContext": {"type": "object"},
+    "containerPort": {"type": "integer", "minimum": 1, "maximum": 65535},
+    "service": {"type": "object", "additionalProperties": false, "required": ["type", "port"], "properties": {"type": {"enum": ["ClusterIP", "NodePort", "LoadBalancer"]}, "port": {"type": "integer", "minimum": 1, "maximum": 65535}}},
+    "ingress": {"type": "object", "additionalProperties": false, "required": ["enabled", "className", "annotations", "hosts", "tls"], "properties": {"enabled": {"type": "boolean"}, "className": {"type": "string"}, "annotations": {"type": "object"}, "hosts": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": false, "required": ["host", "paths"], "properties": {"host": {"type": "string", "minLength": 1}, "paths": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": false, "required": ["path", "pathType"], "properties": {"path": {"type": "string", "pattern": "^/"}, "pathType": {"enum": ["Exact", "Prefix", "ImplementationSpecific"]}}}}}}}, "tls": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["secretName", "hosts"], "properties": {"secretName": {"type": "string", "minLength": 1}, "hosts": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}}}}}},
+    "resources": {"type": "object"},
+    "nodeSelector": {"type": "object"},
+    "tolerations": {"type": "array"},
+    "affinity": {"type": "object"}
+  }
+}

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
   tag: "1.0.1"
-  digest: ""
+  digest: "sha256:8b09f6716f597d99a5c35c1e6a90a22abc8824299be2329b51e6be0a1d6068b3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
-  tag: "1.0.0"
+  tag: "1.0.1"
   digest: ""
   pullPolicy: IfNotPresent
 

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -1,0 +1,61 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/jonfairbanks/k3s-cluster-docs
+  tag: "1.0.0"
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
+containerPort: 8080
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: cluster-docs.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    memory: 64Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Summary

- Add the private OCI chart for the internal cluster handbook
- Enforce non-root, read-only, health-checked runtime defaults
- Publish immutable chart releases to GHCR without adding a catalog entry