### PR TITLE
Release K3s cluster docs 1.0.2

### DIFF
--- a/k3s-cluster-docs/Chart.yaml
+++ b/k3s-cluster-docs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k3s-cluster-docs
 description: Private internal handbook for a K3s cluster
 type: application
-version: 1.0.1
-appVersion: "1.0.1"
+version: 1.0.2
+appVersion: "1.0.2"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/jonfairbanks/k3s-cluster-docs
 sources:

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -2,8 +2,8 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
-  tag: "1.0.1"
-  digest: "sha256:8b09f6716f597d99a5c35c1e6a90a22abc8824299be2329b51e6be0a1d6068b3"
+  tag: "1.0.2"
+  digest: "sha256:83a2acebc02130b03ede1ec4c7e766a849a7ed17ddc520961e5960c525b3e057"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary\n\n- Bump the private K3s handbook chart to 1.0.2\n- Pin the handbook image to its immutable GHCR digest