### PR TITLE
Release K3s cluster docs 1.0.4

### DIFF
--- a/.github/workflows/k3s-cluster-docs.yml
+++ b/.github/workflows/k3s-cluster-docs.yml
@@ -74,6 +74,10 @@ jobs:
           grep --quiet 'readOnlyRootFilesystem: true' /tmp/default.yaml
           grep --quiet 'containerPort: 8080' /tmp/default.yaml
           grep --quiet 'path: /healthz' /tmp/default.yaml
+          grep --quiet 'maxUnavailable: 0' /tmp/default.yaml
+          grep --quiet 'maxSurge: 1' /tmp/default.yaml
+          grep --quiet 'kind: PodDisruptionBudget' /tmp/default.yaml
+          grep --quiet 'minAvailable: 1' /tmp/default.yaml
           grep --quiet 'name: ghcr-pull' /tmp/ingress.yaml
 
   publish:

--- a/k3s-cluster-docs/Chart.yaml
+++ b/k3s-cluster-docs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k3s-cluster-docs
 description: Private internal handbook for a K3s cluster
 type: application
-version: 1.0.3
-appVersion: "1.0.3"
+version: 1.0.4
+appVersion: "1.0.4"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/jonfairbanks/k3s-cluster-docs
 sources:

--- a/k3s-cluster-docs/templates/deployment.yaml
+++ b/k3s-cluster-docs/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "k3s-cluster-docs.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
   selector:
     matchLabels:
       {{- include "k3s-cluster-docs.selectorLabels" . | nindent 6 }}

--- a/k3s-cluster-docs/templates/poddisruptionbudget.yaml
+++ b/k3s-cluster-docs/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "k3s-cluster-docs.fullname" . }}
+  labels:
+    {{- include "k3s-cluster-docs.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "k3s-cluster-docs.selectorLabels" . | nindent 6 }}
+  {{- if ne (toString .Values.podDisruptionBudget.minAvailable) "" }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/k3s-cluster-docs/values.schema.json
+++ b/k3s-cluster-docs/values.schema.json
@@ -2,9 +2,11 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": false,
-  "required": ["replicaCount", "image", "imagePullSecrets", "serviceAccount", "podAnnotations", "podSecurityContext", "securityContext", "containerPort", "service", "ingress", "resources", "nodeSelector", "tolerations", "affinity"],
+  "required": ["replicaCount", "strategy", "podDisruptionBudget", "image", "imagePullSecrets", "serviceAccount", "podAnnotations", "podSecurityContext", "securityContext", "containerPort", "service", "ingress", "resources", "nodeSelector", "tolerations", "affinity"],
   "properties": {
     "replicaCount": {"type": "integer", "minimum": 1},
+    "strategy": {"type": "object", "additionalProperties": false, "required": ["type", "rollingUpdate"], "properties": {"type": {"enum": ["RollingUpdate", "Recreate"]}, "rollingUpdate": {"type": "object", "additionalProperties": false, "required": ["maxUnavailable", "maxSurge"], "properties": {"maxUnavailable": {"type": ["integer", "string"]}, "maxSurge": {"type": ["integer", "string"]}}}}},
+    "podDisruptionBudget": {"type": "object", "additionalProperties": false, "required": ["enabled", "minAvailable", "maxUnavailable"], "properties": {"enabled": {"type": "boolean"}, "minAvailable": {"type": ["integer", "string"]}, "maxUnavailable": {"type": ["integer", "string"]}}},
     "image": {
       "type": "object",
       "additionalProperties": false,

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -1,5 +1,16 @@
 replicaCount: 1
 
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+  maxUnavailable: ""
+
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
   tag: "1.0.4"

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -2,8 +2,8 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
-  tag: "1.0.3"
-  digest: "sha256:4004dc641e2ca63abd03ce53d22f1eebbd812a22c5129ad1a0b181f77d38777e"
+  tag: "1.0.4"
+  digest: "sha256:f75617c93ca9265a9289175179d05757d5671b5e4df43c414c7a2b6f97fcd4aa"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary\n\n- Bump the private K3s handbook chart to 1.0.4\n- Pin the handbook image to its immutable GHCR digest