### PR TITLE
Release K3s cluster docs 1.0.5

### DIFF
--- a/k3s-cluster-docs/Chart.yaml
+++ b/k3s-cluster-docs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k3s-cluster-docs
 description: Private internal handbook for a K3s cluster
 type: application
-version: 1.0.4
-appVersion: "1.0.4"
+version: 1.0.5
+appVersion: "1.0.5"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/jonfairbanks/k3s-cluster-docs
 sources:

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -13,8 +13,8 @@ podDisruptionBudget:
 
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
-  tag: "1.0.4"
-  digest: "sha256:f75617c93ca9265a9289175179d05757d5671b5e4df43c414c7a2b6f97fcd4aa"
+  tag: "1.0.5"
+  digest: "sha256:a8d4077b972dbff29640f0aa79984f7d91edf5cbfe210ec174e6b9fca1718c89"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary\n\n- Bump the private K3s handbook chart to 1.0.5\n- Pin the handbook image to its immutable GHCR digest