### PR TITLE
Release K3s cluster docs 1.0.6

### DIFF
--- a/k3s-cluster-docs/Chart.yaml
+++ b/k3s-cluster-docs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k3s-cluster-docs
 description: Private internal handbook for a K3s cluster
 type: application
-version: 1.0.5
-appVersion: "1.0.5"
+version: 1.0.6
+appVersion: "1.0.6"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/jonfairbanks/k3s-cluster-docs
 sources:

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -13,8 +13,8 @@ podDisruptionBudget:
 
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
-  tag: "1.0.5"
-  digest: "sha256:a8d4077b972dbff29640f0aa79984f7d91edf5cbfe210ec174e6b9fca1718c89"
+  tag: "1.0.6"
+  digest: "sha256:020ec94144fe3c7b3162026c349fd805055fd6b29bb4f13ba771df44f7a326fc"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary\n\n- Bump the private K3s handbook chart to 1.0.6\n- Pin the handbook image to its immutable GHCR digest