### PR TITLE
Release K3s cluster docs 1.0.8

### DIFF
--- a/k3s-cluster-docs/Chart.yaml
+++ b/k3s-cluster-docs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k3s-cluster-docs
 description: Private internal handbook for a K3s cluster
 type: application
-version: 1.0.7
-appVersion: "1.0.7"
+version: 1.0.8
+appVersion: "1.0.8"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/jonfairbanks/k3s-cluster-docs
 sources:

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -13,8 +13,8 @@ podDisruptionBudget:
 
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
-  tag: "1.0.7"
-  digest: "sha256:214a57a3cd9405b2a0b5822d147a9ca8162fad1b4aa9dd12cffa23c3f633a7e9"
+  tag: "1.0.8"
+  digest: "sha256:c77c006e95086a881fed6d97804e88258b153fd4d0b0f4705aa120c14a0616e2"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- Bump the private K3s handbook chart to 1.0.8
- Pin the handbook image to its immutable GHCR digest