### PR TITLE
Release K3s cluster docs 1.0.10

### DIFF
--- a/k3s-cluster-docs/Chart.yaml
+++ b/k3s-cluster-docs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k3s-cluster-docs
 description: Private internal handbook for a K3s cluster
 type: application
-version: 1.0.9
-appVersion: "1.0.9"
+version: 1.0.10
+appVersion: "1.0.10"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/jonfairbanks/k3s-cluster-docs
 sources:

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -13,8 +13,8 @@ podDisruptionBudget:
 
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
-  tag: "1.0.9"
-  digest: "sha256:840fb0848b00a919351ad0d4446c7eea9ffde7a50d823f53001740e22fd3dfd5"
+  tag: "1.0.10"
+  digest: "sha256:2421001a7f7c73ac1320d4e38625166ad18a784fcc978093d5252c1e78903649"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- Bump the private K3s handbook chart to 1.0.10
- Pin the handbook image to its immutable GHCR digest