### PR TITLE
Release K3s cluster docs 1.0.12

### DIFF
--- a/k3s-cluster-docs/Chart.yaml
+++ b/k3s-cluster-docs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k3s-cluster-docs
 description: Private internal handbook for a K3s cluster
 type: application
-version: 1.0.11
-appVersion: "1.0.11"
+version: 1.0.12
+appVersion: "1.0.12"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/jonfairbanks/k3s-cluster-docs
 sources:

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -13,8 +13,8 @@ podDisruptionBudget:
 
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
-  tag: "1.0.11"
-  digest: "sha256:11da8cf80b47a2799789c1ab2dc368b36fd48bd5d18213b0993122b64b0c2e4b"
+  tag: "1.0.12"
+  digest: "sha256:30d453b4e49ccecadd66993c0745be3a83a596392a39a7058652c6f042068863"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- Bump the private K3s handbook chart to 1.0.12
- Pin the handbook image to its immutable GHCR digest