### PR TITLE
Decouple handbook chart version from image version

### DIFF
--- a/k3s-cluster-docs/Chart.yaml
+++ b/k3s-cluster-docs/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k3s-cluster-docs
 description: Private internal handbook for a K3s cluster
 type: application
-version: 1.0.13
-appVersion: "1.0.13"
+version: 1.0.14
+appVersion: "latest"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/jonfairbanks/k3s-cluster-docs
 sources:

--- a/k3s-cluster-docs/values.yaml
+++ b/k3s-cluster-docs/values.yaml
@@ -13,8 +13,11 @@ podDisruptionBudget:
 
 image:
   repository: ghcr.io/jonfairbanks/k3s-cluster-docs
-  tag: "1.0.13"
-  digest: "sha256:ae10ec7659ab8a487869ade56228a48856b3eb4fe1c9da722890f9644c180e58"
+  # Argo CD Image Updater resolves this mutable tag to an immutable digest in
+  # the environment-specific values file. Do not bump this chart for image-only
+  # releases.
+  tag: "latest"
+  digest: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Summary

- Bump the handbook chart once to establish an image-independent chart contract
- Default the image to latest without pinning a release-specific digest
- Reserve future chart version bumps for templates, defaults, or metadata changes